### PR TITLE
feature: allow image in CV header (via URL)

### DIFF
--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -40,6 +40,7 @@ export type ResumeHeaderItem = {
 export type ResumeFrontMatter = {
   readonly name?: string;
   readonly header?: Array<ResumeHeaderItem>;
+  readonly image?: string;
 };
 
 export type Font = {

--- a/site/src/utils/constants/default.ts
+++ b/site/src/utils/constants/default.ts
@@ -21,6 +21,7 @@ export const DEFAULT_STYLES = {
 
 export const DEFAULT_MD_CONTENT = `---
 name: Haha Ha
+image: https://thispersondoesnotexist.com
 header:
   - text: <span class="iconify" data-icon="tabler:phone"></span> (+1) 123-456-7890
   - text: <span class="iconify" data-icon="tabler:mail"></span> renovamenzxh@gmail.com
@@ -213,16 +214,29 @@ ${PREVIEW_SELECTOR} img {
 /* Header */
 
 ${PREVIEW_SELECTOR} .resume-header {
-  text-align: center;
+  display: flex;
+  flex-direction: row;
+  column-gap: 1em;
+  margin-bottom: 1em;
 }
 
-${PREVIEW_SELECTOR} .resume-header h1 {
+${PREVIEW_SELECTOR} .resume-header .header-image {
+  width: 9em;
+  height: 9em;
+}
+
+${PREVIEW_SELECTOR} .resume-header .header-text {
+  text-align: center;
+  flex-grow: 1;
+}
+
+${PREVIEW_SELECTOR} .resume-header .header-text h1 {
   text-align: center;
   line-height: 1;
   margin-bottom: 8px;
 }
 
-${PREVIEW_SELECTOR} .resume-header-item:not(.no-separator)::after {
+${PREVIEW_SELECTOR} .resume-header .header-text-item:not(.no-separator)::after {
   content: " | ";
 }
 

--- a/site/src/utils/markdown.ts
+++ b/site/src/utils/markdown.ts
@@ -41,9 +41,24 @@ const resolveDeflist = (html: string) => {
   return html;
 };
 
+const isValidImageSrc = (string: string) => {
+  let url;
+  try {
+    url = new URL(string);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+};
+
 const resolveHeader = (html: string, frontmatter: ResumeFrontMatter) => {
   let header = "";
+  if (frontmatter.image && isValidImageSrc(frontmatter.image)) {
+    header += `<img class="header-image" src="${frontmatter.image}">\n`;
+  }
 
+  header += `<div class="header-text">\n`;
   if (frontmatter.name) header += `<h1>${frontmatter.name}</h1>\n`;
 
   if (frontmatter.header) {
@@ -65,6 +80,7 @@ const resolveHeader = (html: string, frontmatter: ResumeFrontMatter) => {
 
       header += `</span>\n`;
     }
+    header += `</div>\n`; // close header-wrapper
   }
 
   return `<div class="resume-header">${header}</div>` + html;


### PR DESCRIPTION
I have added a new property called `image` that can be set via the MarkDown attributes. 

You can set the image to any URL and it will be displayed on the left side of the header text.

 If no image is present or if it's not a valid url, it will not be displayed and the layout stays the same as the current one.